### PR TITLE
OpenMPI Fix and disable moving log file

### DIFF
--- a/src/pips_parallel.jl
+++ b/src/pips_parallel.jl
@@ -854,11 +854,11 @@ function structJuMPSolve(model; with_prof=false, suppress_warmings=false,kwargs.
     # end
     @timing with_prof begin
         mid, nprocs = getMyRank()
-        bname = string(split(ARGS[1],"/")[2],"_",num_scenarios(model))
-        run(`mkdir -p ./out/$bname`)
-        fname = string("./out/",bname,"/",bname,"_",nprocs,".",mid,".jl.txt")
-        # @show bname, fname
-        tfile = open(fname, "w")
+        # bname = string(split(ARGS[1],"/")[2],"_",num_scenarios(model))
+        # run(`mkdir -p ./out/$bname`)
+        # fname = string("./out/",bname,"/",bname,"_",nprocs,".",mid,".jl.txt")
+        # # @show bname, fname
+        # tfile = open(fname, "w")
         s1 = @sprintf("[%d/%d] [ t_sj_model_init %f t_sj_solver_total %f  t_sj_lifetime %f ] \n", mid, nprocs, t_sj_model_init, t_sj_solver_total, t_sj_lifetime)
         s2 = @sprintf("[%d/%d] [ t_jl_str_total %f t_jl_eval_total %f  ] \n", mid, nprocs, prob.t_jl_str_total, prob.t_jl_eval_total)
         s3 = @sprintf("[%d/%d] [ t_jac_spconv %f n_jac_spconv %d  ] \n", mid, nprocs, prob.model.t_jac_spconv, prob.model.n_jac_spconv)
@@ -875,16 +875,16 @@ function structJuMPSolve(model; with_prof=false, suppress_warmings=false,kwargs.
             @printf("%s",s6)
             @printf("%s",s7)
         end
-        @printf(tfile, "%s", s1)
-        @printf(tfile, "%s", s2)
-        @printf("%s",s3)
-        @printf("%s",s4)
-        @printf("%s",s5)
-        @printf("%s",s6)
-        @printf("%s",s7)
-        close(tfile)
-        n1 = string("./out/",nprocs,".",mid,".c.txt")
-        n2 = string("./out/",bname,"/",bname,"_",nprocs,".",mid,".c.txt")
+        # @printf(tfile, "%s", s1)
+        # @printf(tfile, "%s", s2)
+        # @printf("%s",s3)
+        # @printf("%s",s4)
+        # @printf("%s",s5)
+        # @printf("%s",s6)
+        # @printf("%s",s7)
+        # close(tfile)
+        # n1 = string("./out/",nprocs,".",mid,".c.txt")
+        # n2 = string("./out/",bname,"/",bname,"_",nprocs,".",mid,".c.txt")
 #        run(`mv $n1 $n2`)
     end
 

--- a/src/pips_parallel.jl
+++ b/src/pips_parallel.jl
@@ -885,7 +885,7 @@ function structJuMPSolve(model; with_prof=false, suppress_warmings=false,kwargs.
         close(tfile)
         n1 = string("./out/",nprocs,".",mid,".c.txt")
         n2 = string("./out/",bname,"/",bname,"_",nprocs,".",mid,".c.txt")
-        run(`mv $n1 $n2`)
+#        run(`mv $n1 $n2`)
     end
 
     return PIPSRetCodeToSolverInterfaceCode[status]

--- a/src/pips_parallel_cfunc.jl
+++ b/src/pips_parallel_cfunc.jl
@@ -7,6 +7,7 @@ module PipsNlpSolver
 using StructJuMPSolverInterface
 import MPI
 
+function __init__()
 try
   sharedLib=ENV["PIPS_NLP_PAR_SHARED_LIB"]
   
@@ -19,6 +20,7 @@ try
 catch 
   warn("Could not load PIPS-NLP shared library. Make sure the ENV variable 'PIPS_NLP_PAR_SHARED_LIB' points to its location, usually in the PIPS repo at PIPS/build_pips/PIPS-NLP/libparpipsnlp.so")
   rethrow()
+end
 end
 
 #######################

--- a/src/pips_parallel_cfunc.jl
+++ b/src/pips_parallel_cfunc.jl
@@ -538,12 +538,12 @@ function createProblemStruct(comm::MPI.Comm, model::ModelInterface, prof::Bool)
     prob = PipsNlpProblemStruct(comm, model, prof)
     # @show prob
     ret = ccall(Libdl.dlsym(libparpipsnlp,:CreatePipsNlpProblemStruct),Ptr{Void},
-            (MPI.Comm, 
+            (MPI.CComm, 
             Cint, Ptr{Void}, Ptr{Void}, 
 	    Ptr{Void}, Ptr{Void}, Ptr{Void}, 
 	    Ptr{Void}, Ptr{Void}, Ptr{Void},Any
             ),
-            comm, 
+            MPI.CComm(comm), 
             model.get_num_scen(),
             str_init_x0_cb,
             str_prob_info_cb,


### PR DESCRIPTION
Moving the log file makes the code crash.

The julia MPI communicator has to be converted otherwise MPI returns with an error. The Julia communicator type is compatible with Fortran MPI. This means it is of type integer. In MPICH, the C communicator is also an integer. However, with OpenMPI this is not true anymore. 